### PR TITLE
Add bootstrap and API startup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ Ziel des Projekts ist es, einem GPT eine persistent abrufbare „mentale Welt“
 ```bash
 git clone https://github.com/Narion2025/Mind.git
 cd Mind
+```
+
+### Quick Start
+
+```bash
+pip install -r requirements.txt
+./start_mind.sh
+curl http://localhost:8000/health
+```

--- a/mind_bootstrap.py
+++ b/mind_bootstrap.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+logger = logging.getLogger(__name__)
+
+DEFAULT_ANCHOR = Path.home() / 'mind_root'
+
+
+def get_anchor() -> Path:
+    anchor_env = os.environ.get('MIND_ANCHOR')
+    anchor = Path(anchor_env) if anchor_env else DEFAULT_ANCHOR
+    try:
+        anchor.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        logger.error(f'Fehler beim Erstellen des Anchor-Verzeichnisses {anchor}: {e}')
+        raise
+    return anchor
+
+
+def ensure_directories(anchor: Path) -> bool:
+    required = [anchor / 'MIND', anchor / 'SKK_OUT']
+    tasks_dir = required[0] / 'tasks'
+    required.append(tasks_dir)
+    created_any = False
+    for d in required:
+        if not d.exists():
+            try:
+                d.mkdir(parents=True, exist_ok=True)
+                created_any = True
+            except Exception as e:
+                logger.error(f'Fehler beim Anlegen des Verzeichnisses {d}: {e}')
+                raise
+    return created_any
+
+
+def start_scheduler_stub():
+    # Platzhalter für Cronjobs oder Scheduler
+    logger.info('Scheduler gestartet (Stub)')
+
+
+def main():
+    anchor = get_anchor()
+    created = ensure_directories(anchor)
+    status = 'Setup-neu' if created else 'Setup-bestehend'
+    logger.info('\U0001F9E0 %s' % status)
+    start_scheduler_stub()
+
+
+if __name__ == '__main__':
+    main()

--- a/mind_bus_api.py
+++ b/mind_bus_api.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+from datetime import datetime
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import yaml
+
+DEFAULT_ANCHOR = Path.home() / 'mind_root'
+
+app = FastAPI()
+
+
+class Task(BaseModel):
+    title: str
+    body: str
+
+
+def get_tasks_dir() -> Path:
+    anchor_env = os.environ.get('MIND_ANCHOR')
+    anchor = Path(anchor_env) if anchor_env else DEFAULT_ANCHOR
+    tasks_dir = anchor / 'MIND' / 'tasks'
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    return tasks_dir
+
+
+@app.post('/task')
+async def create_task(task: Task):
+    tasks_dir = get_tasks_dir()
+    ts = datetime.now().strftime('%Y%m%d%H%M%S')
+    path = tasks_dir / f'{ts}.yaml'
+    try:
+        with open(path, 'w', encoding='utf-8') as f:
+            yaml.dump(task.dict(), f, allow_unicode=True)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {'status': 'saved', 'path': str(path)}
+
+
+@app.get('/health')
+async def health():
+    return 'ok'
+
+
+def start():
+    port = int(os.environ.get('PORT', 8000))
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=port)
+
+
+if __name__ == '__main__':
+    start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ websocket-client>=1.6.1
 requests>=2.31.0
 python-dotenv>=1.0.0
 playsound==1.2.2
+fastapi
+uvicorn[standard]

--- a/start_mind.sh
+++ b/start_mind.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python3 mind_bootstrap.py &
+PORT=${PORT:-8000} python3 mind_bus_api.py


### PR DESCRIPTION
## Summary
- add `mind_bootstrap.py` to initialize directories and show setup status
- implement minimal FastAPI app `mind_bus_api.py`
- add shell wrapper `start_mind.sh`
- update requirements with FastAPI and Uvicorn
- extend README with quick start instructions

## Testing
- `python3 -m py_compile mind_bootstrap.py mind_bus_api.py`


------
https://chatgpt.com/codex/tasks/task_b_685b13156e9883228f2e455bfcfca281