### PR TITLE
Integrate Hive bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,28 @@ Beispiel:
 ```bash
 curl -X POST ws://localhost:8080/speak -d '{"agent":"imerion","text":"Hallo"}'
 ```
+
+## Onboarding The Hive
+
+Die Integration des Hive-Agenten erfolgt über ein erweitertes Bootstrap:
+
+1. SKK-Scheduler importieren und mit Test-String starten:
+   ```bash
+   echo "[hive_boot] import SKKScheduler …"
+   python3 tools/skk/skk_autoanalyse_scheduler.py Boot-Test
+   ```
+2. MIND-Cleanup-Setup im Trockenlauf testen:
+   ```bash
+   python3 tools/hive_cleanup_setup.py --dry-run
+   ```
+3. Benötigte Ordner sicherstellen (`tools/skk/`, `SKK_OUT/`, `config/markers`, `semnet/`,
+   `modules/`, `thoughts/`, `wiki/`, `blob/`, `logs/`).
+4. Cronjob für den Hive-Scheduler eintragen:
+   ```bash
+   0 0 * * * python3 tools/skk/skk_autoanalyse_scheduler.py --daily
+   ```
+5. Hive-Resonanz mit einem einfachen API-Call testen:
+   ```bash
+   curl -X POST http://localhost:8000/task -d '{"agent":"hive_regulator","body":"Test Hive-Resonanz"}'
+   ```
+6. Optional übernimmt `./hive_quick_setup.sh` alle obigen Schritte in einem Rutsch.

--- a/hive_quick_setup.sh
+++ b/hive_quick_setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+# Quick bootstrap for The Hive
+echo "[hive_boot] Quick setup starting"
+./mind_bootstrap.sh

--- a/mind_bootstrap.sh
+++ b/mind_bootstrap.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Start the Python bootstrap to initialize base directories
+python3 mind_bootstrap.py
+
+# ===== Hive Boot Block =====
+# 1. SKK-Scheduler Import
+echo "[hive_boot] import SKKScheduler …"
+python3 - <<'PY'
+from tools.skk.skk_autoanalyse_scheduler import SKKScheduler
+SKKScheduler().analyze_daily_input("Boot-Test")
+PY
+
+# 2. Cleanup Setup Dry Run
+mkdir -p logs
+python3 tools/hive_cleanup_setup.py --dry-run | tee -a logs/hive_cleanup.log
+
+# 3. Ensure directory structure
+mkdir -p tools/skk SKK_OUT config/markers semnet modules thoughts wiki blob logs
+
+# 4. Cron entry for Hive Scheduler
+CRON_LINE="0 0 * * * python3 $(pwd)/tools/skk/skk_autoanalyse_scheduler.py --daily"
+(crontab -l 2>/dev/null; echo "$CRON_LINE") | sort -u | crontab -
+
+# 5. Hive Resonance Test
+curl -X POST http://localhost:8000/task -d '{"agent":"hive_regulator","body":"Test Hive-Resonanz"}' || true
+

--- a/tools/hive_cleanup_setup.py
+++ b/tools/hive_cleanup_setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import argparse
+from datetime import datetime
+
+parser = argparse.ArgumentParser(description="Hive cleanup setup")
+parser.add_argument("--dry-run", action="store_true", help="run in dry-run mode")
+parser.add_argument("--commit", action="store_true", help="apply cleanup")
+args = parser.parse_args()
+
+mode = "DRY-RUN" if args.dry_run else "COMMIT" if args.commit else "UNKNOWN"
+print(f"[hive_cleanup] {datetime.now().isoformat()} running cleanup in {mode} mode")

--- a/tools/skk/skk_autoanalyse_scheduler.py
+++ b/tools/skk/skk_autoanalyse_scheduler.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from datetime import datetime
+import argparse
+
+class SKKScheduler:
+    def analyze_daily_input(self, text: str):
+        print(f"[SKKScheduler] {datetime.now().isoformat()} Analyzing: {text}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--daily", action="store_true", help="run daily analysis")
+    parser.add_argument("input", nargs="?", default="Daily run")
+    args = parser.parse_args()
+    sched = SKKScheduler()
+    sched.analyze_daily_input(args.input)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Hive bootstrap steps in new `mind_bootstrap.sh`
- create a quick setup helper `hive_quick_setup.sh`
- stub SKK scheduler and cleanup utilities
- document Hive onboarding procedure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b38d4d9c48322b6dcb58283b184d1