### PR TITLE
Add agent action endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ Localtunnel bereitgestellt.
 - **`mind_bus_api.py`** – FastAPI-Backend für GPT-Anchors und das Dashboard.
 - **Dashboard** – statische Dateien unter `mind_dashboard_bundle`. Aufruf über `/dashboard`.
 
+## Anchor Actions
+
+Über `POST /agents/{id}/action` lassen sich Anchors verbinden, pausieren oder löschen.
+
+Gültige `op`-Werte:
+
+- `connect` – legt den Anchor an und setzt ihn online
+- `pause` – schaltet den Anchor offline
+- `delete` – entfernt den Anchor
+
+Beispiel:
+
+```bash
+curl -X POST http://localhost:8000/agents/imerion/action \
+  -H 'Content-Type: application/json' \
+  -d '{"op":"connect","model":"gpt-4o","identity":"Imerion","params":{}}'
+```
+
+Alle Aktionen erfolgen per `POST /agents/{id}/action` – es gibt kein `PATCH`.
+
 ## 🔊 Voice Pipeline
 
 Installiere Node.js-Abhängigkeiten und starte anschließend den Voice-Server:

--- a/mind_bus_api.py
+++ b/mind_bus_api.py
@@ -2,17 +2,21 @@ import os
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import PlainTextResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, constr
+from pydantic import BaseModel, constr, root_validator, validator
 
-app = FastAPI()
+app = FastAPI(openapi_tags=[
+    {"name": "anchor", "x-openai-isConsequential": True},
+    {"name": "action", "x-openai-isConsequential": True},
+])
 
 # in-memory anchor storage
 anchors: Dict[str, Dict] = {}
+update_clients: List[WebSocket] = []
 
 bundle_dir = Path(__file__).resolve().parent / "mind_dashboard_bundle"
 app.mount("/dashboard", StaticFiles(directory=str(bundle_dir), html=True), name="dashboard")
@@ -31,6 +35,29 @@ class AnchorIn(BaseModel):
 class Anchor(AnchorIn):
     gpt_id: GptID
     created_at: str
+
+
+class AgentAction(BaseModel):
+    op: str
+    model: Optional[ModelLiteral] = None
+    identity: Optional[str] = None
+    params: Optional[Dict] = None
+
+    @validator('op')
+    def validate_op(cls, v):
+        if v not in {'connect', 'pause', 'delete'}:
+            raise ValueError('invalid op')
+        return v
+
+    @root_validator
+    def connect_requires_fields(cls, values):
+        if values.get('op') == 'connect':
+            if values.get('model') is None or values.get('params') is None:
+                raise ValueError('model and params required')
+        return values
+
+    class Config:
+        extra = 'forbid'
 
 @app.put("/anchors/{gpt_id}")
 async def upsert_anchor(gpt_id: str, anchor: AnchorIn):
@@ -58,6 +85,58 @@ async def get_state(gpt_id: str):
 @app.get("/health")
 async def health():
     return "ok"
+
+
+async def broadcast_update(event: str, gpt_id: str):
+    for ws in list(update_clients):
+        try:
+            await ws.send_json({"event": event, "id": gpt_id})
+        except WebSocketDisconnect:
+            update_clients.remove(ws)
+
+
+@app.websocket("/ws/updates")
+async def ws_updates(ws: WebSocket):
+    await ws.accept()
+    update_clients.append(ws)
+    try:
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        update_clients.remove(ws)
+
+
+@app.post("/agents/{gpt_id}/action", tags=["action"])
+async def agent_action(gpt_id: str, payload: AgentAction):
+    if payload.op == "connect":
+        now = datetime.utcnow().isoformat()
+        created_at = anchors.get(gpt_id, {}).get("created_at", now)
+        anchors[gpt_id] = {
+            "gpt_id": gpt_id,
+            "identity": payload.identity,
+            "model": payload.model,
+            "version": anchors.get(gpt_id, {}).get("version", "1.0.0"),
+            "online": True,
+            "created_at": created_at,
+            "config": {
+                "identity": payload.identity,
+                "model": payload.model,
+                "params": payload.params,
+            },
+        }
+        await broadcast_update("anchor-connected", gpt_id)
+        return anchors[gpt_id]
+    if gpt_id not in anchors:
+        raise HTTPException(status_code=404, detail="not found")
+    if payload.op == "pause":
+        anchors[gpt_id]["online"] = False
+        await broadcast_update("anchor-paused", gpt_id)
+        return anchors[gpt_id]
+    if payload.op == "delete":
+        anchors.pop(gpt_id)
+        await broadcast_update("anchor-deleted", gpt_id)
+        return {"status": "deleted"}
+    raise HTTPException(status_code=400, detail="invalid op")
 
 def start():
     port = int(os.environ.get("API_PORT") or os.environ.get("PORT", 8000))

--- a/mind_dashboard_bundle/index.html
+++ b/mind_dashboard_bundle/index.html
@@ -10,7 +10,7 @@
   <h1>Gateway Dashboard</h1>
   <button id="addBtn">Neuen GPT hinzufügen</button>
   <table id="anchors">
-    <thead><tr><th>ID</th><th>Name</th><th>Model</th><th>Status</th></tr></thead>
+    <thead><tr><th>ID</th><th>Name</th><th>Model</th><th>Status</th><th>Aktionen</th></tr></thead>
     <tbody></tbody>
   </table>
 

--- a/mind_dashboard_bundle/main.js
+++ b/mind_dashboard_bundle/main.js
@@ -9,7 +9,7 @@ async function fetchAnchors() {
   data.forEach(a => {
     const tr = document.createElement('tr');
     const status = a.online ? 'online' : 'offline';
-    tr.innerHTML = `<td>${a.gpt_id}</td><td>${a.identity}</td><td>${a.model}</td><td><span class="badge ${status}">${status}</span></td>`;
+    tr.innerHTML = `<td>${a.gpt_id}</td><td>${a.identity}</td><td>${a.model}</td><td><span class="badge ${status}">${status}</span></td><td><button class="pauseBtn" data-id="${a.gpt_id}">Pause</button> <button class="deleteBtn" data-id="${a.gpt_id}">Delete</button></td>`;
     tbody.appendChild(tr);
   });
 }
@@ -26,13 +26,13 @@ document.getElementById('anchorForm').onsubmit = async (e) => {
   e.preventDefault();
   const id = document.getElementById('gpt_id').value;
   const payload = {
+    op: 'connect',
     identity: document.getElementById('identity').value,
     model: document.getElementById('model').value,
-    version: document.getElementById('version').value,
-    online: true
+    params: {}
   };
-  const res = await fetch(`${API_BASE}/anchors/${id}`, {
-    method: 'PUT',
+  const res = await fetch(`${API_BASE}/agents/${id}/action`, {
+    method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(payload)
   });
@@ -46,3 +46,25 @@ document.getElementById('anchorForm').onsubmit = async (e) => {
 
 fetchAnchors();
 setInterval(fetchAnchors, 5000);
+
+document.addEventListener('click', async (e) => {
+  if (e.target.classList.contains('pauseBtn')) {
+    const id = e.target.dataset.id;
+    await fetch(`${API_BASE}/agents/${id}/action`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({op: 'pause'})
+    });
+    fetchAnchors();
+  }
+  if (e.target.classList.contains('deleteBtn')) {
+    const id = e.target.dataset.id;
+    if (!confirm('Delete Agent?')) return;
+    await fetch(`${API_BASE}/agents/${id}/action`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({op: 'delete'})
+    });
+    fetchAnchors();
+  }
+});

--- a/mind_dashboard_bundle/style.css
+++ b/mind_dashboard_bundle/style.css
@@ -4,3 +4,4 @@ th,td{border:1px solid #ccc;padding:0.5rem;text-align:left;}
 #modal{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.3);display:flex;align-items:center;justify-content:center;}
 .hidden{display:none;}
 .badge.online{color:green;}
+.badge.offline{color:red;}

--- a/tests/e2e_agent_actions.py
+++ b/tests/e2e_agent_actions.py
@@ -1,0 +1,55 @@
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+
+
+def get_free_port():
+    s = socket.socket()
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def req(method, url, data=None):
+    if data is not None:
+        data = json.dumps(data).encode()
+    req = urllib.request.Request(url, data=data, method=method)
+    if data is not None:
+        req.add_header('Content-Type', 'application/json')
+    with urllib.request.urlopen(req) as resp:
+        return resp.getcode(), resp.read().decode()
+
+
+def test_agent_action_e2e():
+    port = get_free_port()
+    env = os.environ.copy()
+    env['API_PORT'] = str(port)
+    proc = subprocess.Popen([sys.executable, 'mind_bus_api.py'], env=env)
+    try:
+        time.sleep(1.5)
+        code, _ = req('POST', f'http://localhost:{port}/agents/e2e/action', {
+            'op': 'connect', 'model': 'gpt-4o', 'identity': 'E2E', 'params': {}
+        })
+        assert code == 200
+        code, anchors = req('GET', f'http://localhost:{port}/anchors')
+        anchors = json.loads(anchors)
+        assert any(a['gpt_id'] == 'e2e' for a in anchors)
+        code, _ = req('POST', f'http://localhost:{port}/agents/e2e/action', {'op':'pause'})
+        assert code == 200
+        code, anchors = req('GET', f'http://localhost:{port}/anchors')
+        anchors = json.loads(anchors)
+        a = next(a for a in anchors if a['gpt_id']=='e2e')
+        assert a['online'] is False
+        code, _ = req('POST', f'http://localhost:{port}/agents/e2e/action', {'op':'delete'})
+        assert code == 200
+        code, anchors = req('GET', f'http://localhost:{port}/anchors')
+        anchors = json.loads(anchors)
+        assert not any(a['gpt_id']=='e2e' for a in anchors)
+    finally:
+        proc.terminate()
+        proc.wait()

--- a/tests/test_gateway_api.py
+++ b/tests/test_gateway_api.py
@@ -42,6 +42,12 @@ def request(method, url, data=None):
         return e.code, e.read().decode()
 
 
+def connect(port, id):
+    payload = {"op": "connect", "model": "gpt-4o", "identity": "Test", "params": {}}
+    code, _ = request('POST', f'http://localhost:{port}/agents/{id}/action', payload)
+    assert code == 200
+
+
 def test_put_anchor_valid(start_api):
     port = start_api
     payload = {"identity": "Test", "model": "gpt-4o", "version": "1.0.0"}
@@ -77,3 +83,30 @@ def test_state_and_list(start_api):
     code, body = request('GET', f'http://localhost:{port}/state?gpt_id=test3')
     assert code == 200
     assert body == 'online'
+
+
+def test_action_connect_invalid_model(start_api):
+    port = start_api
+    payload = {"op": "connect", "model": "wrong", "identity": "X", "params": {}}
+    code, _ = request('POST', f'http://localhost:{port}/agents/a1/action', payload)
+    assert code == 422
+
+
+def test_action_flow(start_api):
+    port = start_api
+    connect(port, 'flow1')
+    code, body = request('GET', f'http://localhost:{port}/anchors')
+    anchors = json.loads(body)
+    a = next(a for a in anchors if a['gpt_id'] == 'flow1')
+    assert a['online'] is True
+    code, _ = request('POST', f'http://localhost:{port}/agents/flow1/action', {"op": "pause"})
+    assert code == 200
+    code, body = request('GET', f'http://localhost:{port}/anchors')
+    anchors = json.loads(body)
+    a = next(a for a in anchors if a['gpt_id'] == 'flow1')
+    assert a['online'] is False
+    code, _ = request('POST', f'http://localhost:{port}/agents/flow1/action', {"op": "delete"})
+    assert code == 200
+    code, body = request('GET', f'http://localhost:{port}/anchors')
+    anchors = json.loads(body)
+    assert not any(x['gpt_id'] == 'flow1' for x in anchors)


### PR DESCRIPTION
## Summary
- implement `/agents/{gpt_id}/action` for connect/pause/delete
- add websocket updates and dashboard controls
- document new actions in README
- update dashboard to use new endpoint
- add unit and e2e tests for actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b6fa45bf0832289058c50cfa8834c