### PR TITLE
Fix pydantic constr usage and improve test startup checks

### DIFF
--- a/mind_bus_api.py
+++ b/mind_bus_api.py
@@ -67,9 +67,15 @@ bundle_dir = Path(__file__).resolve().parent / "mind_dashboard_bundle"
 app.mount("/dashboard", StaticFiles(directory=str(bundle_dir), html=True), name="dashboard")
 
 # Pydantic models
-ModelLiteral = constr(regex="^(gpt-4o|claude-3|gemini-pro)$")
-VersionStr = constr(regex=r"^\d+\.\d+\.\d+$")
-GptID = constr(regex=r"^[a-z0-9_-]{3,32}$")
+# ``constr`` changed the ``regex`` parameter name to ``pattern`` in
+# pydantic v2. Detect the installed version and use the appropriate
+# keyword so the API works under both v1 and v2.
+import pydantic
+
+_constr_kw = 'pattern' if pydantic.version.VERSION.startswith('2') else 'regex'
+ModelLiteral = constr(**{_constr_kw: "^(gpt-4o|claude-3|gemini-pro)$"})
+VersionStr = constr(**{_constr_kw: r"^\d+\.\d+\.\d+$"})
+GptID = constr(**{_constr_kw: r"^[a-z0-9_-]{3,32}$"})
 
 class AnchorIn(BaseModel):
     identity: str

--- a/tests/e2e_agent_actions.py
+++ b/tests/e2e_agent_actions.py
@@ -32,6 +32,8 @@ def test_agent_action_e2e():
     proc = subprocess.Popen([sys.executable, 'mind_bus_api.py'], env=env)
     try:
         time.sleep(1.5)
+        if proc.poll() is not None:
+            raise RuntimeError("API server failed to start")
         code, _ = req('POST', f'http://localhost:{port}/agents/e2e/action', {
             'op': 'connect', 'model': 'gpt-4o', 'identity': 'E2E', 'params': {}
         })

--- a/tests/e2e_register_anchor.py
+++ b/tests/e2e_register_anchor.py
@@ -32,6 +32,8 @@ def test_register_anchor_e2e():
     proc = subprocess.Popen([sys.executable, 'mind_bus_api.py'], env=env)
     try:
         time.sleep(1.5)
+        if proc.poll() is not None:
+            raise RuntimeError("API server failed to start")
         payload = {'identity': 'E2E', 'model': 'gpt-4o', 'version': '1.0.0'}
         code, _ = req('PUT', f'http://localhost:{port}/anchors/e2e', payload)
         assert code == 200

--- a/tests/test_gateway_api.py
+++ b/tests/test_gateway_api.py
@@ -24,6 +24,9 @@ def start_api():
     env['API_PORT'] = str(port)
     proc = subprocess.Popen([sys.executable, 'mind_bus_api.py'], env=env)
     time.sleep(1.0)
+    # Fail fast if the server crashed during startup
+    if proc.poll() is not None:
+        raise RuntimeError("API server failed to start")
     yield port
     proc.terminate()
     proc.wait()


### PR DESCRIPTION
## Summary
- support both pydantic v1 and v2 in `mind_bus_api.py`
- fail fast in tests if API server fails to start

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685bc5dd8dc88322bc322d37694b6eb5