### PR TITLE
Improve startup scripts and add GPT scaffold tool

### DIFF
--- a/mind_gateway.sh
+++ b/mind_gateway.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+PORT=${PORT:-8000}
+API_PORT=${API_PORT:-$PORT}
+
+PIDS=$(lsof -t -i :$API_PORT 2>/dev/null)
+if [[ -n "$PIDS" ]]; then
+  echo "Killing processes on port $API_PORT: $PIDS"
+  kill $PIDS 2>/dev/null || true
+  sleep 1
+fi
+
+exec ./start_gateway.sh "$@"

--- a/start_all.sh
+++ b/start_all.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
-ENV_PY="narion-env/bin/python3"
+ENV_PY="${ENV_PY:-narion-env/bin/python3}"
+
+PORT=8000
+PIDS=$(lsof -t -i :$PORT 2>/dev/null)
+if [[ -n "$PIDS" ]]; then
+  echo "Killing processes on port $PORT: $PIDS"
+  kill $PIDS 2>/dev/null || true
+  sleep 1
+fi
+
+echo "Starte Gateway..."
+./mind_gateway.sh &
+sleep 1
 
 echo "Starte Narion Agent..."
 $ENV_PY narion_emotion_loop.py &

--- a/start_gateway.sh
+++ b/start_gateway.sh
@@ -16,9 +16,11 @@ elif [[ -n $1 ]]; then
   usage
 fi
 
-if lsof -i :$API_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
-  echo "Error: port $API_PORT is already in use" >&2
-  exit 1
+PIDS=$(lsof -t -i :$API_PORT 2>/dev/null)
+if [[ -n "$PIDS" ]]; then
+  echo "Killing processes on port $API_PORT: $PIDS"
+  kill $PIDS 2>/dev/null || true
+  sleep 1
 fi
 
 export PORT=$API_PORT

--- a/tools/create_gpt.py
+++ b/tools/create_gpt.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+import textwrap
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create scaffold for a new GPT agent")
+    parser.add_argument("name", help="Name of the GPT/agent")
+    args = parser.parse_args()
+
+    base = Path(args.name)
+    base.mkdir(exist_ok=True)
+
+    server_js = f"""const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const app = express();
+
+const yamlPath = path.join(__dirname, '{args.name}.yaml');
+
+if (!fs.existsSync(yamlPath)) {{
+  fs.writeFileSync(yamlPath, '# auto-generated anchor\n', 'utf8');
+  console.log('✅ {args.name}.yaml wurde erzeugt.');
+}}
+
+app.get('/init/anchors/{args.name}.yaml', (req, res) => {{
+  res.setHeader('Content-Type', 'application/yaml');
+  fs.createReadStream(yamlPath).pipe(res);
+}});
+
+app.listen(PORT, () => {{
+  console.log(`🚀 {args.name} Server läuft unter http://localhost:${{PORT}}`);
+}});
+"""
+    (base / "server.js").write_text(server_js)
+
+    package_json = {
+        "name": f"{args.name}-server",
+        "version": "1.0.0",
+        "scripts": {"start": "node server.js"},
+        "dependencies": {"express": "^4.18.4"}
+    }
+    (base / "package.json").write_text(json.dumps(package_json, indent=2))
+    (base / "package-lock.json").write_text('{}\n')
+    (base / "node_modules").mkdir(exist_ok=True)
+
+    yaml_content = textwrap.dedent(f"""
+    {args.name}_assistant:
+      name: "{args.name}"
+      role: "Resonanzfeld und semantischer Seher"
+      description: >
+        {args.name} ist ein Interface für semantische Tiefenanalyse, systemische Mustererkennung
+        und techno-emotionale Rückkopplung. Er wird aktiviert bei Drift, Markerhäufung
+        oder explizitem Aufruf zur Deutung.
+
+      endpoint:
+        url: "http://localhost:4060/dante/reflect"
+        method: POST
+        expected_input:
+          - marker_stream: List[Marker]
+          - drift_state: DriftAchse
+          - optional_context: String
+        response:
+          - insight_vector: PromptVector
+          - knot_prediction: Optional[KnotID]
+          - semantic_commentary: Text
+
+      triggers:
+        - condition: "marker_count >= 3 && drift_aktiv"
+          action: "call /{args.name}/reflect"
+        - condition: "user_role == 'coach' && system_feedback_needed"
+          action: "call /{args.name}/reflect"
+
+      actions:
+        - name: "reflect"
+          description: >
+            Verarbeitet Marker und Drift, generiert semantischen InsightVector, optional
+            Diagramm oder Knotenvorhersage. Kommentiert mit Bedeutungsschicht.
+        - name: "comment"
+          description: >
+            Liefert reine Text-Resonanz – keine Entscheidung, sondern Spiegel.
+
+      constraints:
+        - max_tokens: 800
+        - call_frequency: "once per turn or on semantic shift"
+        - no_diagnosis: true
+        - no_decision_making: true
+
+      integration_notes:
+        - {args.name} benötigt kein permanentes Memory, arbeitet kontextuell.
+        - Nur aktivieren, wenn Feedback-Schicht gewünscht ist.
+        - Diagrammausgabe optional – durch knot_logic_module visualisierbar.
+    """)
+
+    (base / f"{args.name}.yaml").write_text(yaml_content)
+
+    print(f"📁 created GPT scaffold in {base}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script to generate a new GPT directory with a YAML template
- kill existing processes on port 8000 before starting the gateway
- add `mind_gateway.sh` wrapper that ensures the port is free
- start the gateway in `start_all.sh`

## Testing
- `pytest -q`
- `bash -n start_gateway.sh`
- `bash -n mind_gateway.sh`
- `bash -n start_all.sh`
- `python3 -m py_compile tools/create_gpt.py`

------
https://chatgpt.com/codex/tasks/task_b_685c41f6b2a88322823f9ecf5caade48