### PR TITLE
Add GUI initializer and fix dashboard server

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Localtunnel bereitgestellt.
 - **`start_gateway.sh`** – prüft den freien Port (Standard `8000`), optional mit `--tunnel` für einen öffentlichen Link. Startet `mind_bus_api.py`.
 - **`mind_bus_api.py`** – FastAPI-Backend für GPT-Anchors und das Dashboard.
 - **Dashboard** – statische Dateien unter `mind_dashboard_bundle`. Aufruf über `/dashboard`.
+- **`mind_init_all.py`** – kleine Tkinter-Oberfläche zum Starten von Server,
+  Gateway und Dashboard. Aufruf: `python3 mind_init_all.py`.
 
 ## Anchor Actions
 

--- a/mind_init_all.py
+++ b/mind_init_all.py
@@ -1,0 +1,60 @@
+import subprocess
+import threading
+import webbrowser
+import tkinter as tk
+from tkinter import scrolledtext
+
+processes = {}
+
+
+def start_process(name, cmd):
+    if name in processes and processes[name].poll() is None:
+        return
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    processes[name] = proc
+    threading.Thread(target=_pipe_output, args=(name, proc), daemon=True).start()
+
+
+def _pipe_output(name, proc):
+    for line in proc.stdout:
+        log.insert(tk.END, f"[{name}] {line}")
+        log.see(tk.END)
+    proc.wait()
+    log.insert(tk.END, f"[{name}] exited\n")
+    log.see(tk.END)
+    processes.pop(name, None)
+
+
+def start_server():
+    start_process("server", ["python3", "mind_bus_api.py"])
+    webbrowser.open("http://localhost:8000/dashboard")
+
+
+def start_agent_gateway():
+    start_process("gateway", ["python3", "wirklichkeits-api/gateway.py"])
+
+
+def start_html():
+    start_process("dashboard", ["node", "server.js"])
+    webbrowser.open("http://localhost:8001")
+
+
+root = tk.Tk()
+root.title("Mind Init")
+
+frame = tk.Frame(root)
+frame.pack(padx=10, pady=10, fill="x")
+
+btn1 = tk.Button(frame, text="Start Server", command=start_server)
+btn1.pack(fill="x")
+
+btn2 = tk.Button(frame, text="Start Agent Integration", command=start_agent_gateway)
+btn2.pack(fill="x", pady=5)
+
+btn3 = tk.Button(frame, text="Start Dashboard", command=start_html)
+btn3.pack(fill="x")
+
+log = scrolledtext.ScrolledText(root, height=20)
+log.pack(fill="both", expand=True, padx=10, pady=10)
+
+root.mainloop()

--- a/server.js
+++ b/server.js
@@ -7,10 +7,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Absolute Pfadangabe zum Public-Ordner
-const publicPath = path.join(__dirname, "MIND-Dashboard-Bundle", "public");
+// Die Dateien liegen im Ordner "mind_dashboard_bundle" im Repo
+const publicPath = path.join(__dirname, "mind_dashboard_bundle");
 
 const app = express();
-const PORT = process.env.PORT || 8000;
+const PORT = process.env.PORT || 8001;
 
 // Static Assets bereitstellen
 app.use(express.static(publicPath));
@@ -19,6 +20,6 @@ app.use(express.static(publicPath));
 app.get("*", (_, res) => {
   res.sendFile(path.join(publicPath, "index.html"));
 });
-app.listen(8000, '0.0.0.0', () => {
-  console.log("🧠 Narion MIND Server läuft öffentlich auf Port 8000");
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`🧠 Narion MIND Server läuft öffentlich auf Port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add `mind_init_all.py` for starting Mind services via simple Tkinter GUI
- update dashboard server path and port
- document new GUI script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d1275464883229c155d0efd787790