### PR TITLE
Add GPT scaffold utility and improve gateway startup

### DIFF
--- a/AGENT_INTEGRATION.md
+++ b/AGENT_INTEGRATION.md
@@ -38,3 +38,13 @@ Unter `/custom_gpt_setup.html` befindet sich ein einfaches Formular. Die Eingabe
 `action/custom_gpt_manager.yaml` beschreibt die API für ChatGPT-Functions. Binden Sie diese Datei ein und rufen Sie `createAnchor` bzw. `patchAnchor` auf, um einen Agenten zu registrieren. Anschließend kann der Agent seine YAML-Dateien für Gedanken, Narrative oder Wissenseinträge ablegen.
 
 Für die Verbindung werden die Umgebungsvariablen `JWT_PUBLIC_KEY` und optional `HMAC_SECRET` benötigt. Ohne gültiges JWT bzw. HMAC lehnt der Gateway die Anfrage ab.
+
+## 5. GPT-Ordner erzeugen
+
+Mit `create_gpt_scaffold.py` kann ein neuer Agent inklusive Anker-Server und YAML-Vorlage angelegt werden:
+
+```bash
+python3 create_gpt_scaffold.py MyGPT --description "Kurzer Archetyp"
+```
+
+Es entsteht der Ordner `MyGPT/` mit `server.js`, `package.json`, `package-lock.json` und `MyGPT.yaml`. Der Express-Server liefert die YAML unter `/init/anchors/MyGPT.yaml` aus.

--- a/create_gpt_scaffold.py
+++ b/create_gpt_scaffold.py
@@ -1,0 +1,113 @@
+import argparse
+from pathlib import Path
+import json
+
+SERVER_JS_TEMPLATE = """const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const app = express();
+
+const ankerFilePath = path.join(__dirname, '{name}.yaml');
+
+if (!fs.existsSync(ankerFilePath)) {{
+  fs.writeFileSync(ankerFilePath, '# auto-generiert\n', 'utf8');
+  console.log('\u2705 {name}.yaml wurde erzeugt.');
+}}
+
+app.get('/init/anchors/{name}.yaml', (req, res) => {{
+  res.setHeader('Content-Type', 'application/yaml');
+  fs.createReadStream(ankerFilePath).pipe(res);
+}});
+
+app.listen(PORT, () => {{
+  console.log(`\u{1F680} {name} Server l\u00E4uft auf http://localhost:${{PORT}}`);
+}});
+"""
+
+YAML_TEMPLATE = """{name}_assistant:
+  name: "{name}"
+  role: "Resonanzfeld und semantischer Seher"
+  description: >
+    {description}
+
+endpoint:
+  url: "http://localhost:4060/{name}/reflect"
+  method: POST
+  expected_input:
+    - marker_stream: List[Marker]
+    - drift_state: DriftAchse
+    - optional_context: String
+  response:
+    - insight_vector: PromptVector
+    - knot_prediction: Optional[KnotID]
+    - semantic_commentary: Text
+
+triggers:
+  - condition: "marker_count >= 3 && drift_aktiv"
+    action: "call /{name}/reflect"
+  - condition: "user_role == 'coach' && system_feedback_needed"
+    action: "call /{name}/reflect"
+
+actions:
+  - name: "reflect"
+    description: >
+      Verarbeitet Marker und Drift, generiert semantischen InsightVector, optional Diagramm oder Knotenvorhersage. Kommentiert mit Bedeutungsschicht.
+  - name: "comment"
+    description: >
+      Liefert reine Text-Resonanz – keine Entscheidung, sondern Spiegel.
+
+constraints:
+  - max_tokens: 800
+  - call_frequency: "once per turn or on semantic shift"
+  - no_diagnosis: true
+  - no_decision_making: true
+
+integration_notes:
+  - {name} ben\u00F6tigt kein permanentes Memory, arbeitet kontextuell.
+  - Nur aktivieren, wenn Feedback-Schicht gew\u00FCnscht ist.
+  - Diagrammausgabe optional – durch knot_logic_module visualisierbar.
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate scaffold for a new GPT agent")
+    parser.add_argument("name", help="Name of the GPT agent")
+    parser.add_argument("--description", default="", help="Kurzbeschreibung oder Archetyp")
+    args = parser.parse_args()
+
+    base = Path(args.name)
+    base.mkdir(exist_ok=True)
+
+    # server.js
+    server_js = base / "server.js"
+    if not server_js.exists():
+        server_js.write_text(SERVER_JS_TEMPLATE.format(name=args.name))
+
+    # package.json
+    package_json = base / "package.json"
+    if not package_json.exists():
+        data = {
+            "name": args.name.lower(),
+            "version": "1.0.0",
+            "description": f"YAML-Anker Server f\u00FCr {args.name}",
+            "main": "server.js",
+            "scripts": {"start": "node server.js"},
+            "dependencies": {"express": "^4.18.4"}
+        }
+        package_json.write_text(json.dumps(data, indent=2))
+
+    lock = base / "package-lock.json"
+    if not lock.exists():
+        lock.write_text("{}\n")
+
+    yaml_path = base / f"{args.name}.yaml"
+    if not yaml_path.exists():
+        yaml_path.write_text(YAML_TEMPLATE.format(name=args.name, description=args.description or ""))
+
+    print(f"\u2714 Scaffold f\u00FCr {args.name} angelegt unter {base}")
+
+
+if __name__ == "__main__":
+    main()

--- a/start_all.sh
+++ b/start_all.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 ENV_PY="narion-env/bin/python3"
+PORT=${API_PORT:-8000}
+if lsof -i :$PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+  echo "Killing processes on port $PORT" >&2
+  lsof -ti :$PORT -sTCP:LISTEN | xargs -r kill
+  sleep 1
+fi
 
 echo "Starte Narion Agent..."
 $ENV_PY narion_emotion_loop.py &

--- a/start_gateway.sh
+++ b/start_gateway.sh
@@ -17,8 +17,9 @@ elif [[ -n $1 ]]; then
 fi
 
 if lsof -i :$API_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
-  echo "Error: port $API_PORT is already in use" >&2
-  exit 1
+  echo "Killing processes on port $API_PORT" >&2
+  lsof -ti :$API_PORT -sTCP:LISTEN | xargs -r kill
+  sleep 1
 fi
 
 export PORT=$API_PORT


### PR DESCRIPTION
## Summary
- add script `create_gpt_scaffold.py` to generate a new GPT folder with server and YAML template
- document new script in `AGENT_INTEGRATION.md`
- ensure `start_all.sh` and `start_gateway.sh` kill processes on the gateway port before starting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c41f6b2a88322823f9ecf5caade48