### PR TITLE
Fix validation path for thought files

### DIFF
--- a/MIND_CI_Validation/scripts/validate_thoughts.py
+++ b/MIND_CI_Validation/scripts/validate_thoughts.py
@@ -66,7 +66,9 @@ else:  # pragma: no cover - validation skipped
 
         return
 
-BASE = Path(__file__).resolve().parents[1]
+# ``validate_thoughts.py`` lives in ``MIND_CI_Validation/scripts``.  The project
+# root is two levels up from this file.
+BASE = Path(__file__).resolve().parents[2]
 SCHEMA_PATH = BASE / "MIND_CI_Validation" / "schema" / "thought_entry.schema.yml"
 THOUGHTS_DIR = BASE / "thoughts" / "entries"
 


### PR DESCRIPTION
## Summary
- correct `validate_thoughts.py` base directory calculation so CI can find the thoughts folder

## Testing
- `pytest -q`
- `python MIND_CI_Validation/scripts/validate_thoughts.py`

------
https://chatgpt.com/codex/tasks/task_b_685d3c2f49448322a1e032614d9c9c8b