### PR TITLE
Add GPT instance bootstrap modules

### DIFF
--- a/bootstrap_identity.py
+++ b/bootstrap_identity.py
@@ -1,0 +1,38 @@
+import os
+import yaml
+from modules.marker_grapper import MarkerGrapper
+from modules.marker_selfwriter import MarkerSelfwriter
+from modules.color_utils import do_color_test, get_marker_sets_for
+
+
+def bootstrap_identity(name: str):
+    farbe = do_color_test()
+    reinforce, contrast = get_marker_sets_for(farbe)
+
+    choice = input("Verstärkend (v) oder kontrastierend (k)?: ").strip().lower()
+    include_sets = [reinforce] if choice != "k" else [contrast]
+
+    filter_tags = []
+
+    config = {
+        "name": name,
+        "farbe": farbe,
+        "marker_view": {
+            "include_sets": include_sets,
+            "filter_tags": filter_tags,
+        },
+    }
+
+    os.makedirs(name, exist_ok=True)
+    path = os.path.join(name, f"{farbe}.yaml")
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(config, f, allow_unicode=True)
+
+    grapper = MarkerGrapper(include_sets=include_sets, filter_tags=filter_tags)
+    selfwriter = MarkerSelfwriter(os.path.join(name, "self_written"))
+    return grapper, selfwriter
+
+
+if __name__ == "__main__":
+    g, w = bootstrap_identity("Assistent_Kairos")
+    print("Bootstrap abgeschlossen. MarkerGrapper und MarkerSelfwriter initialisiert")

--- a/modules/color_utils.py
+++ b/modules/color_utils.py
@@ -1,0 +1,25 @@
+import random
+
+COLORS = ["rot", "türkis", "blau", "grün", "violett"]
+
+
+def do_color_test():
+    print("Farbtest - wähle eine Farbe: " + ", ".join(COLORS))
+    choice = input("Deine Farbe: ").strip().lower()
+    if choice not in COLORS:
+        choice = random.choice(COLORS)
+        print(f"Unbekannte Farbe, nehme zufällig: {choice}")
+    return choice
+
+
+_COLOR_MAP = {
+    "türkis": ("resonance", "fraud"),
+    "rot": ("tension", "calm"),
+    "blau": ("clarity", "chaos"),
+    "grün": ("growth", "decay"),
+    "violett": ("vision", "doubt"),
+}
+
+
+def get_marker_sets_for(color):
+    return _COLOR_MAP.get(color, ("default", "contrast"))

--- a/modules/marker_grapper.py
+++ b/modules/marker_grapper.py
@@ -1,0 +1,51 @@
+import glob
+import os
+from typing import List, Dict
+
+import yaml
+import toml
+
+
+class MarkerGrapper:
+    """Lädt Markerdateien und erkennt vorkommende Muster im Text."""
+
+    def __init__(self, marker_dir: str = "config/markers", include_sets: List[str] | None = None,
+                 filter_tags: List[str] | None = None):
+        self.include_sets = set(include_sets or [])
+        self.filter_tags = set(filter_tags or [])
+        self.markers = []
+        self._load_marker_files(marker_dir)
+
+    def _load_marker_files(self, marker_dir: str):
+        files = glob.glob(os.path.join(marker_dir, "*.yaml")) + glob.glob(os.path.join(marker_dir, "*.toml"))
+        for path in files:
+            data = None
+            if path.endswith(".yaml"):
+                with open(path, "r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f)
+            elif path.endswith(".toml"):
+                data = toml.load(path)
+            if not isinstance(data, dict):
+                continue
+            self._collect_markers(data)
+
+    def _collect_markers(self, data: Dict):
+        for name, spec in data.items():
+            sets = set(spec.get("set") or spec.get("sets") or [])
+            tags = set(spec.get("tags", []))
+            patterns = spec.get("muster") or spec.get("patterns") or []
+            if self.include_sets and not (self.include_sets & sets):
+                continue
+            if self.filter_tags and not (self.filter_tags & tags):
+                continue
+            self.markers.append({"name": name, "patterns": patterns, "tags": tags})
+
+    def grap_text(self, text: str) -> List[str]:
+        text_lower = text.lower()
+        found = []
+        for marker in self.markers:
+            for p in marker["patterns"]:
+                if p.lower() in text_lower:
+                    found.append(marker["name"])
+                    break
+        return found

--- a/modules/marker_selfwriter.py
+++ b/modules/marker_selfwriter.py
@@ -1,0 +1,39 @@
+import os
+from collections import Counter
+from typing import List
+
+import yaml
+
+
+class MarkerSelfwriter:
+    """Erstellt neue Marker aus dem Gesprächsverlauf."""
+
+    def __init__(self, base_dir: str):
+        self.base_dir = base_dir
+        os.makedirs(base_dir, exist_ok=True)
+        self.history: List[str] = []
+
+    def observe(self, text: str):
+        self.history.append(text)
+
+    def _collect_candidates(self) -> List[str]:
+        counter = Counter()
+        for line in self.history:
+            for word in line.lower().split():
+                counter[word.strip('.,!?:;')] += 1
+        return [w for w, c in counter.items() if c >= 3]
+
+    def write_markers(self):
+        for word in self._collect_candidates():
+            path = os.path.join(self.base_dir, f"{word}.yaml")
+            if os.path.exists(path):
+                continue
+            data = {
+                word: {
+                    "beschreibung": f"Automatisch generierter Marker für '{word}'",
+                    "muster": [word],
+                    "tags": ["drift", "auto"],
+                }
+            }
+            with open(path, "w", encoding="utf-8") as f:
+                yaml.safe_dump(data, f, allow_unicode=True)


### PR DESCRIPTION
## Summary
- add color utility to pick a colour and pick marker sets
- create `MarkerGrapper` for loading marker files and spotting patterns
- create `MarkerSelfwriter` to generate new markers from conversations
- implement `bootstrap_identity.py` to initialise an assistant, save config and return grapper/selfwriter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d65f932cc83228ddafeb109a5aca7