### PR TITLE
Implement YAML swarm and agent creator GUI

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import yaml
+
+BASE_DIR = Path('mind_root') / 'schwarm'
+MINDS_DIR = BASE_DIR / 'minds'
+
+
+def create_agent(name: str, farbe: str, fokus: str, beschreibung: str) -> Path:
+    """Erzeugt Dateien und Verzeichnisse für einen neuen Agenten."""
+    agent_dir = BASE_DIR / name
+    for sub in ['wiki', 'sort', 'narrative', 'lineage']:
+        (agent_dir / sub).mkdir(parents=True, exist_ok=True)
+    MINDS_DIR.mkdir(parents=True, exist_ok=True)
+    data = {
+        'name': name,
+        'farbe': farbe,
+        'fokus': fokus,
+        'beschreibung': beschreibung,
+        'ordner': str(agent_dir),
+        'elemente': ['wiki/', 'sort/', 'narrative/', 'lineage/'],
+    }
+    yaml_path = MINDS_DIR / f'{name}.yaml'
+    with yaml_path.open('w', encoding='utf-8') as fh:
+        yaml.safe_dump(data, fh, allow_unicode=True)
+    script = agent_dir / f'activate_{name}.py'
+    if not script.exists():
+        script.write_text('def activate():\n    pass\n')
+    return yaml_path

--- a/mind_bus_api.py
+++ b/mind_bus_api.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect, Back
 from fastapi.responses import PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, constr, root_validator, validator
+from agent_manager import create_agent
 
 app = FastAPI(openapi_tags=[
     {"name": "anchor", "x-openai-isConsequential": True},
@@ -110,6 +111,14 @@ class AgentAction(BaseModel):
     class Config:
         extra = 'forbid'
 
+
+class NewAgent(BaseModel):
+    name: constr(**{_constr_kw: r"^[a-zA-Z0-9_-]{1,32}$"})
+    farbe: str
+    fokus: str
+    beschreibung: str
+
+
 @app.put("/anchors/{gpt_id}")
 async def upsert_anchor(gpt_id: str, anchor: AnchorIn):
     if not re.match(r"^[a-z0-9_-]{3,32}$", gpt_id):
@@ -188,6 +197,12 @@ async def agent_action(gpt_id: str, payload: AgentAction):
         await broadcast_update("anchor-deleted", gpt_id)
         return {"status": "deleted"}
     raise HTTPException(status_code=400, detail="invalid op")
+
+
+@app.post('/agents', tags=['agent'])
+async def create_new_agent(agent: NewAgent):
+    create_agent(agent.name, agent.farbe, agent.fokus, agent.beschreibung)
+    return {'status': 'created'}
 
 
 # --- Function control API ---

--- a/mind_dashboard_bundle/agent_creator.html
+++ b/mind_dashboard_bundle/agent_creator.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>Agent Creator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Neuen Agenten anlegen</h1>
+  <form id="agentForm">
+    <label>Name <input id="name" required></label><br>
+    <label>Farbe <input id="farbe" required></label><br>
+    <label>Fokus <input id="fokus" required></label><br>
+    <label>Beschreibung <input id="beschreibung" required></label><br>
+    <button type="submit">Anlegen</button>
+  </form>
+  <pre id="status"></pre>
+  <script src="agent_creator.js"></script>
+</body>
+</html>

--- a/mind_dashboard_bundle/agent_creator.js
+++ b/mind_dashboard_bundle/agent_creator.js
@@ -1,0 +1,24 @@
+const API_BASE = window.API_BASE || '';
+
+const form = document.getElementById('agentForm');
+form.onsubmit = async (e) => {
+  e.preventDefault();
+  const payload = {
+    name: document.getElementById('name').value.trim(),
+    farbe: document.getElementById('farbe').value.trim(),
+    fokus: document.getElementById('fokus').value.trim(),
+    beschreibung: document.getElementById('beschreibung').value.trim()
+  };
+  const res = await fetch(`${API_BASE}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const status = document.getElementById('status');
+  if(res.ok){
+    status.textContent = 'Agent erstellt';
+    form.reset();
+  }else{
+    status.textContent = 'Fehler: ' + await res.text();
+  }
+};

--- a/mind_root/schwarm/README.md
+++ b/mind_root/schwarm/README.md
@@ -1,0 +1,2 @@
+# Schwarmstruktur
+Dieses Verzeichnis enthält die kollaborativen Daten des YAML-Schwarms.

--- a/mind_root/schwarm/bedeutung/README.md
+++ b/mind_root/schwarm/bedeutung/README.md
@@ -1,0 +1,2 @@
+# Bedeutung
+Einträge zur erlebten Bedeutung. Pro Agent ist höchstens ein Eintrag pro Stunde öffentlich.

--- a/mind_root/schwarm/erkenntnis/README.md
+++ b/mind_root/schwarm/erkenntnis/README.md
@@ -1,0 +1,2 @@
+# Erkenntnis
+Geteiltes Wissen und kollaborativ wachsende Einträge.

--- a/mind_root/schwarm/impuls/README.md
+++ b/mind_root/schwarm/impuls/README.md
@@ -1,0 +1,2 @@
+# Impuls
+Offene Fragen zur Systemverbesserung und entsprechende Antworten.

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -1,0 +1,71 @@
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import yaml
+import urllib.request
+
+
+def get_free_port():
+    s = socket.socket()
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def request(method, url, data=None):
+    if data is not None:
+        data = json.dumps(data).encode()
+    req = urllib.request.Request(url, data=data, method=method)
+    if data is not None:
+        req.add_header('Content-Type', 'application/json')
+    with urllib.request.urlopen(req) as resp:
+        return resp.getcode(), resp.read().decode()
+
+
+def start_api():
+    port = get_free_port()
+    env = os.environ.copy()
+    env['API_PORT'] = str(port)
+    proc = subprocess.Popen([sys.executable, 'mind_bus_api.py'], env=env)
+    time.sleep(1.0)
+    if proc.poll() is not None:
+        raise RuntimeError('API server failed to start')
+    return proc, port
+
+
+def test_yaml_integritaet(tmp_path):
+    base = Path('mind_root/schwarm/minds')
+    base.mkdir(parents=True, exist_ok=True)
+    (base / 'dummy.yaml').write_text('name: dummy')
+    for f in base.glob('*.yaml'):
+        yaml.safe_load(f.read_text())
+
+
+def test_gui_funktion_neuer_agent():
+    proc, port = start_api()
+    try:
+        payload = {
+            'name': 'tester',
+            'farbe': 'blau',
+            'fokus': 'tests',
+            'beschreibung': 'ein test'
+        }
+        code, _ = request('POST', f'http://localhost:{port}/agents', payload)
+        assert code == 200
+        yaml_path = Path('mind_root/schwarm/minds/tester.yaml')
+        assert yaml_path.exists()
+        data = yaml.safe_load(yaml_path.read_text())
+        assert data['name'] == 'tester'
+        for d in ['wiki', 'sort', 'narrative', 'lineage']:
+            assert (Path('mind_root/schwarm/tester') / d).is_dir()
+    finally:
+        proc.terminate()
+        proc.wait()
+
+


### PR DESCRIPTION
## Summary
- add `agent_manager.py` to manage swarm agents
- extend `mind_bus_api.py` with agent creation API
- provide simple HTML/JS GUI for creating agents
- introduce swarm directory with README files
- test YAML integrity and agent creation

## Testing
- `pip install ruamel.yaml pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685db723305c8322996f4b04456e17ef