### PR TITLE
Add terminal cockpit feature

### DIFF
--- a/mind_bus_api.py
+++ b/mind_bus_api.py
@@ -274,6 +274,46 @@ async def ws_logs(ws: WebSocket, name: str):
         pass
 
 
+@app.websocket("/ws/terminal")
+async def ws_terminal(ws: WebSocket):
+    """Provide a simple interactive shell over WebSocket.
+
+    Access is gated via the ``ENABLE_TERMINAL`` environment variable. If it is
+    not set to ``"1"`` the connection will be closed immediately.
+    """
+    await ws.accept()
+    if os.environ.get("ENABLE_TERMINAL") != "1":
+        await ws.close(code=1008)
+        return
+
+    proc = await asyncio.create_subprocess_exec(
+        "bash", "-i",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+    async def read_stream():
+        while True:
+            data = await proc.stdout.readline()
+            if not data:
+                break
+            await ws.send_text(data.decode())
+
+    reader = asyncio.create_task(read_stream())
+    try:
+        while True:
+            msg = await ws.receive_text()
+            proc.stdin.write(msg.encode())
+            await proc.stdin.drain()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        proc.kill()
+        await proc.wait()
+        reader.cancel()
+
+
 @app.get('/env')
 async def env_status():
     out: Dict[str, List[str]] = {}

--- a/mind_dashboard_bundle/main.js
+++ b/mind_dashboard_bundle/main.js
@@ -62,6 +62,24 @@ function openLogs(name){
   document.getElementById('closeLogs').onclick=()=>{ws.close();drawer.classList.add('hidden');};
 }
 
+document.getElementById('openTerminal').onclick = () => {
+  const drawer = document.getElementById('terminalDrawer');
+  drawer.classList.remove('hidden');
+  const pre = document.getElementById('terminalOutput');
+  pre.textContent = '';
+  const input = document.getElementById('terminalInput');
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  const ws = new WebSocket(`${proto}://${location.host}/ws/terminal`);
+  ws.onmessage = e => { pre.textContent += e.data; pre.scrollTop = pre.scrollHeight; };
+  input.onkeydown = ev => {
+    if(ev.key === 'Enter'){
+      ws.send(input.value + '\n');
+      input.value = '';
+    }
+  };
+  document.getElementById('closeTerminal').onclick = () => { ws.close(); drawer.classList.add('hidden'); };
+};
+
 // Anchor logic from legacy dashboard
 async function fetchAnchors(){
   const res=await fetch(`${API_BASE}/anchors`);

--- a/mind_dashboard_bundle/mind_control.html
+++ b/mind_dashboard_bundle/mind_control.html
@@ -8,11 +8,26 @@
 </head>
 <body>
   <h1>Mind Control Hub</h1>
-  <input id="search" placeholder="Suche..." />
-  <div id="groups"></div>
 
-  <h2>Aktive Agenten</h2>
-  <div id="agents"></div>
+  <div id="dashboard">
+    <section class="module" id="functionsSection">
+      <h2>Funktionen</h2>
+      <input id="search" placeholder="Suche..." />
+      <div id="groups"></div>
+    </section>
+
+    <section class="module" id="agentsSection">
+      <h2>Aktive Agenten</h2>
+      <div id="agents"></div>
+      <button id="openTerminal">Terminal</button>
+    </section>
+  </div>
+
+  <div id="terminalDrawer" class="hidden">
+    <button id="closeTerminal">Schließen</button>
+    <pre id="terminalOutput"></pre>
+    <input id="terminalInput" placeholder="Befehl" />
+  </div>
 
   <div id="logDrawer" class="hidden">
     <button id="closeLogs">Schließen</button>

--- a/mind_dashboard_bundle/style.css
+++ b/mind_dashboard_bundle/style.css
@@ -1,8 +1,11 @@
 body{font-family:Arial, sans-serif;padding:1rem;}
-section{border:1px solid #ccc;margin-bottom:1rem;padding:0.5rem;}
+.module{border:1px solid #ccc;margin-bottom:1rem;padding:0.5rem;}
 .function{display:flex;align-items:center;gap:0.5rem;margin:0.25rem 0;}
+#dashboard{display:flex;flex-wrap:wrap;gap:1rem;}
 .pill{display:inline-block;width:10px;height:10px;border-radius:50%;}
 #logDrawer{position:fixed;bottom:0;left:0;right:0;height:200px;background:#000;color:#0f0;padding:0.5rem;overflow:auto;}
 .hidden{display:none;}
 .badge.online{color:green;}
 .badge.offline{color:red;}
+#terminalDrawer{position:fixed;bottom:0;left:0;right:0;height:200px;background:#111;color:#0f0;padding:0.5rem;overflow:auto;}
+#terminalInput{width:100%;box-sizing:border-box;background:#222;color:#0f0;border:none;padding:0.25rem;}


### PR DESCRIPTION
## Summary
- add websocket terminal to `mind_bus_api.py`
- add terminal panel to dashboard HTML/JS/CSS
- gate shell endpoint with `ENABLE_TERMINAL`
- reorganize dashboard layout using modular sections

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686a553af8ec8322b74159bacf338796