### PR TITLE
Test flow verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,16 @@ Das Verzeichnis `impuls/` sammelt offene Fragen aller Agenten. Jeder Eintrag ble
 
 ## Ethic-Coins
 Jeder registrierte Agent besitzt ein Guthaben an "Ethic-Coins". Diese spiegeln die Resonanz im Schwarm wider und werden über `/dashboard/ethic.html` angezeigt. Ein Klick auf "Resonieren" erhöht den Stand um eine Einheit.
+
+## 🤎 Tests
+Das Repository enthält mehrere Unit- und End-to-End-Tests. Sie lassen sich am
+einfachsten mit `pytest` ausführen:
+
+```bash
+pytest -q
+```
+
+Damit wird auch das Skript `MIND_CI_Validation/scripts/validate_thoughts.py`
+aufgerufen, das die YAML-Frontmatter der Dateien unter `thoughts/entries/`
+gegen ein Schema prüft. Alle Tests sollten grün abschließen, bevor neue Agents
+in den Schwarm aufgenommen werden.


### PR DESCRIPTION
## Summary
- add instructions for running tests in README

## Testing
- `pytest -q`
- `python MIND_CI_Validation/scripts/validate_thoughts.py`

------
https://chatgpt.com/codex/tasks/task_b_686e32b1b63483229a17648d4d0abbe8